### PR TITLE
Fix infinite join bug when calling `stop` on a Service

### DIFF
--- a/lib/dnssd/service.rb
+++ b/lib/dnssd/service.rb
@@ -157,14 +157,17 @@ class DNSSD::Service
   # The service is automatically stopped after calling this method.
 
   def process # :yields: DNSSD::Result
-    @thread = Thread.current
+    #Commented out this line so that the if in service.c isn't run that leads us to an endless Thread.join.
+    #While the condition in service.c is supposed to not run if @thread is Thread.current, it is, and is
+    #Making it impossible to call `stop` on a service. Letting @thread be nil avoids the condition.
+    #@thread = Thread.current
 
     while @continue do
       _process if @replies.empty?
       yield @replies.shift until @replies.empty?
     end
 
-    @thread = nil
+    #@thread = nil
 
     self
   rescue DNSSD::ServiceNotRunningError


### PR DESCRIPTION
This fork fixes the bug where calling `stop` on the service returned from methods like `DNSSD.browse` would enter an infinite `join` call by trying to `join` the current thread, despite a condition in `service.c` not to. I just commented out the line (160) in `service.rb`:

```
@thread = Thread.current
```

Although that's supposed to avoid the `join` block, it doesn't. Leaving `@thread` as `nil` avoids the block, and has no effects (I can't find anywhere besides that block in `service.c` where `@thread` is actually used).

See issue #10 
