### PR TITLE
Add netinet/in.h include

### DIFF
--- a/ext/dnssd/service.c
+++ b/ext/dnssd/service.c
@@ -1,3 +1,4 @@
+#include <netinet/in.h>
 #include "dnssd.h"
 
 static VALUE mDNSSD;


### PR DESCRIPTION
Linux doesn't need this explicit include, but the BSDs do.